### PR TITLE
Add CI: type-check & build on PRs to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Type-check & build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `npm run build` is `tsc && vite build`, so this gates both the
+      # TypeScript type-check and a clean production build.
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `npm run build` (`tsc && vite build`) on pull requests and pushes to `master`.

- Node from `.nvmrc` (v22), `npm ci`, then `npm run build`
- Gates both the TypeScript type-check and a clean production build before code can reach `master` (and thus the deployed `gh-pages` site)
- Validation only — does **not** deploy; `npm run deploy` stays manual

Once this passes and merges, the `Type-check & build` check becomes available to require in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)